### PR TITLE
Add the ability to handle templates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ $ smarky create "extract a gzipped tarball (.tar.gz)" "tar xvzf "
 $ # press Ctrl + J here
 ```
 
+### Templated Bookmarks
+
+On top of just storing your commands, smarky comes with another ZLE widget that
+allows you to jump to the next "template" field. Fields are simply parts of the
+command wrapped in double curly braces, like such:
+
+```sh
+socat {{ protocol }}-listen:{{ port }},fork,reuseaddr {{ protocol }}:{{ remote ip addr }}:{{ port }}
+```
+
+You can store something like this, or text that is even more complicated, place
+it in the command line from smarky by pressing Ctrl + J, then jump to the first
+field with Ctrl + G.
+
+Pressing Ctrl + G again and again will jump to the next field, if one exists.
+You can even take this opportunity to invoke more well-behaved widgets.
+
 ### Index file (SQLite database)
 
 When picking the database file to be used by the `sqlite3` command, smarky has

--- a/README.md
+++ b/README.md
@@ -22,36 +22,27 @@ smarky depends on: `fzf`, `sqlite3`, `bat` (optional)
 
 ## Usage
 
-```
-Usage information:
-  smarky create [description] [command] ----- add a mark to the index
-  smarky update id [description] [command] -- edit a mark in the index
-  smarky remove id -------------------------- remove command by id
-  smarky select id -------------------------- get command by id
-  smarky list ------------------------------- list all added commands
-  smarky [help|usage|etc.] ------------------ display usage information
-```
+You can get usage information by invoking `smarky` directly, but the main
+script itself is a very simple CRUD:
 
-While smarky can be used by directly invoking the command, it's made to be
-simple enough it becomes a little useless when you want to retrieve commands to
-use in real time. To get more use out of it, you'll need to use ZSH and the
-accompanying ZLE widget present in this repository.
+![smarky is just a CRUD](https://user-images.githubusercontent.com/8827351/174419214-bc65c62a-a2ea-4fff-b826-d53503825573.gif)
 
-The default binding to retrieve commands from smarky using a widget is
-`Ctrl-J`. You can get the binding and the widget in your shell configuration by
-adding the following to your `.zshrc`:
+This is by design. You can use it directly if you like, but you're encouraged
+to just pipe it around. The project's focus is on possible applications of it,
+two of which are the ZLE widgets present in this repository.
+
+If you choose to use the widgets as they are in this repository, the binding to
+retrieve commands from smarky is `Ctrl-J` by default. You can get the binding
+and the widget in your shell configuration by adding the following to your
+`.zshrc`:
 
 ```sh
 source path/to/the/smarky/repo/zsh/widgets.zsh
 ```
 
-Once that is done, add bookmarks to smarky and press Ctrl-J to see the fzf
-widget that'll help you select your bookmark and put it on the command line:
+This is what it looks like in action:
 
-```sh
-$ smarky create "extract a gzipped tarball (.tar.gz)" "tar xvzf "
-$ # press Ctrl + J here
-```
+![smarky ZLE widget](https://user-images.githubusercontent.com/8827351/174420744-fd6ce2f1-1e98-4fed-80b0-69b5cfc9740d.gif)
 
 ### Templated Bookmarks
 
@@ -65,9 +56,11 @@ socat {{ protocol }}-listen:{{ port }},fork,reuseaddr {{ protocol }}:{{ remote i
 
 You can store something like this, or text that is even more complicated, place
 it in the command line from smarky by pressing Ctrl + J, then jump to the first
-field with Ctrl + G.
+field with Ctrl + G, pressing the same combination for the next field, and the
+next, and so on:
 
-Pressing Ctrl + G again and again will jump to the next field, if one exists.
+![smarky templated commands](https://user-images.githubusercontent.com/8827351/174421186-028d50ac-8df2-440a-8c4d-a6ccb8a1f4a9.gif)
+
 You can even take this opportunity to invoke more well-behaved widgets.
 
 ### Index file (SQLite database)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ next, and so on:
 
 ![smarky templated commands](https://user-images.githubusercontent.com/8827351/174421186-028d50ac-8df2-440a-8c4d-a6ccb8a1f4a9.gif)
 
-You can even take this opportunity to invoke more well-behaved widgets.
+After you jump to a field, control reverts back to ZSH itself, so if you have
+widgets for things like getting a Git commit hash, getting the name of a Git
+branch, or things of the sort (including getting another command from smarky),
+you may do so freely.
 
 ### Index file (SQLite database)
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,6 @@ next, and so on:
 
 ![smarky templated commands](https://user-images.githubusercontent.com/8827351/174421186-028d50ac-8df2-440a-8c4d-a6ccb8a1f4a9.gif)
 
-After you jump to a field, control reverts back to ZSH itself, so if you have
-widgets for things like getting a Git commit hash, getting the name of a Git
-branch, or things of the sort (including getting another command from smarky),
-you may do so freely.
-
 ### Index file (SQLite database)
 
 When picking the database file to be used by the `sqlite3` command, smarky has

--- a/zsh/widgets.zsh
+++ b/zsh/widgets.zsh
@@ -17,7 +17,6 @@ fzf-smarky-next-field() {
   [ -z "$RBUFFER" ] && CURSOR=0
   local fieldstart='{{' fieldend='}}'
   local subtracted="${RBUFFER#*$fieldstart}" offset
-  echo "$subtracted" > /tmp/subtracted.txt
   offset=$(( ${#RBUFFER} - ${#subtracted} - ${#fieldstart} + $CURSOR ))
   CURSOR=offset; RBUFFER="${RBUFFER#*$fieldend}"
 }

--- a/zsh/widgets.zsh
+++ b/zsh/widgets.zsh
@@ -8,7 +8,7 @@ fzf-smarky-pick-command() {
   selected="$(smarky list | fzf --height 40% --tiebreak=index \
     --preview "$previewcmd" | cut -d' ' -f1 | xargs -r smarky select)"
 
-  LBUFFER="$selected"
+  [ -n "$selected" ] && LBUFFER="$selected"
   zle reset-prompt
 }
 

--- a/zsh/widgets.zsh
+++ b/zsh/widgets.zsh
@@ -12,5 +12,16 @@ fzf-smarky-pick-command() {
   zle reset-prompt
 }
 
+fzf-smarky-next-field() {
+  setopt localoptions noglobsubst noposixbuiltins pipefail 2>/dev/null
+  [ -z "$RBUFFER" ] && CURSOR=0
+  local subtracted="${RBUFFER#*\{\{}" offset
+  offset=$(( ${#RBUFFER} - ${#subtracted} - 2 + $CURSOR ))
+  CURSOR=offset; RBUFFER="${RBUFFER#*\}\}}"
+}
+
 zle -N fzf-smarky-pick-command
 bindkey '^J' fzf-smarky-pick-command
+
+zle -N fzf-smarky-next-field
+bindkey '^G' fzf-smarky-next-field

--- a/zsh/widgets.zsh
+++ b/zsh/widgets.zsh
@@ -15,9 +15,11 @@ fzf-smarky-pick-command() {
 fzf-smarky-next-field() {
   setopt localoptions noglobsubst noposixbuiltins pipefail 2>/dev/null
   [ -z "$RBUFFER" ] && CURSOR=0
-  local subtracted="${RBUFFER#*\{\{}" offset
-  offset=$(( ${#RBUFFER} - ${#subtracted} - 2 + $CURSOR ))
-  CURSOR=offset; RBUFFER="${RBUFFER#*\}\}}"
+  local fieldstart='{{' fieldend='}}'
+  local subtracted="${RBUFFER#*$fieldstart}" offset
+  echo "$subtracted" > /tmp/subtracted.txt
+  offset=$(( ${#RBUFFER} - ${#subtracted} - ${#fieldstart} + $CURSOR ))
+  CURSOR=offset; RBUFFER="${RBUFFER#*$fieldend}"
 }
 
 zle -N fzf-smarky-pick-command


### PR DESCRIPTION
Add the ability to handle templated bookmarks by creating a ZLE widget to jump
to the next template field.

Commands containing parts surrounded by double curly braces (`{{`) are not
considered "templated bookmarks", and smarky now has a ZLE widget to jump to the
next field with Ctrl + G.

Might suffer extensive modification in the future to make it more friendly,
highlighting the template fields so they're clearly visible to the user instead
of just replacing them entirely upon pressing the "next-field" keybind.

Closes #3.
